### PR TITLE
Improve plugin i18n

### DIFF
--- a/src/Test_Reports/Settings.php
+++ b/src/Test_Reports/Settings.php
@@ -231,16 +231,16 @@ class Settings {
 				</div>
 
 				<div class="test-reports-templates">
-					<?php $report_template->print_report_template( esc_html__( 'Bug Report', 'test-reports' ), 'bug-report', 'trac' ); ?>
-					<?php $report_template->print_report_template( esc_html__( 'Bug Report', 'test-reports' ), 'bug-report', 'github', true ); ?>
+					<?php $report_template->print_report_template( 'Bug Report', 'bug-report', 'trac' ); ?>
+					<?php $report_template->print_report_template( 'Bug Report', 'bug-report', 'github', true ); ?>
 
-					<?php $report_template->print_report_template( esc_html__( 'Reproduction Report', 'test-reports' ), 'bug-reproduction', 'trac', true ); ?>
-					<?php $report_template->print_report_template( esc_html__( 'Reproduction Report', 'test-reports' ), 'bug-reproduction', 'github', true ); ?>
+					<?php $report_template->print_report_template( 'Reproduction Report', 'bug-reproduction', 'trac', true ); ?>
+					<?php $report_template->print_report_template( 'Reproduction Report', 'bug-reproduction', 'github', true ); ?>
 
-					<?php $report_template->print_report_template( esc_html__( 'Test Report', 'test-reports' ), 'patch-testing', 'trac', true ); ?>
-					<?php $report_template->print_report_template( esc_html__( 'Test Report', 'test-reports' ), 'patch-testing', 'github', true ); ?>
+					<?php $report_template->print_report_template( 'Test Report', 'patch-testing', 'trac', true ); ?>
+					<?php $report_template->print_report_template( 'Test Report', 'patch-testing', 'github', true ); ?>
 
-					<?php $report_template->print_report_template( esc_html__( 'Security Vulnerability', 'test-reports' ), 'security-vulnerability', 'github', true ); ?>
+					<?php $report_template->print_report_template( 'Security Vulnerability', 'security-vulnerability', 'github', true ); ?>
 				</div>
 		</div>
 		<?php

--- a/src/Test_Reports/Settings.php
+++ b/src/Test_Reports/Settings.php
@@ -187,25 +187,25 @@ class Settings {
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-type" value="bug-report" checked>
-										Bug Report
+										<?php esc_html_e( 'Bug Report', 'test-reports' ); ?>
 									</label>
 								</div>
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-type" value="bug-reproduction">
-										Bug Reproduction
+										<?php esc_html_e( 'Bug Reproduction', 'test-reports' ); ?>
 									</label>
 								</div>
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-type" value="patch-testing">
-										Patch Testing
+										<?php esc_html_e( 'Patch Testing', 'test-reports' ); ?>
 									</label>
 								</div>
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-type" value="security-vulnerability">
-										Security Vulnerability
+										<?php esc_html_e( 'Security Vulnerability', 'test-reports' ); ?>
 									</label>
 								</div>
 							</fieldset>
@@ -216,13 +216,13 @@ class Settings {
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-location" value="trac" checked>
-										Trac
+										<?php esc_html_e( 'Trac', 'test-reports' ); ?>
 									</label>
 								</div>
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-location" value="github">
-										GitHub
+										<?php esc_html_e( 'GitHub', 'test-reports' ); ?>
 									</label>
 								</div>
 							</fieldset>
@@ -231,16 +231,16 @@ class Settings {
 				</div>
 
 				<div class="test-reports-templates">
-					<?php $report_template->print_report_template( 'Bug Report', 'bug-report', 'trac' ); ?>
-					<?php $report_template->print_report_template( 'Bug Report', 'bug-report', 'github', true ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Bug Report', 'test-reports' ), 'bug-report', 'trac' ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Bug Report', 'test-reports' ), 'bug-report', 'github', true ); ?>
 
-					<?php $report_template->print_report_template( 'Reproduction Report', 'bug-reproduction', 'trac', true ); ?>
-					<?php $report_template->print_report_template( 'Reproduction Report', 'bug-reproduction', 'github', true ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Reproduction Report', 'test-reports' ), 'bug-reproduction', 'trac', true ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Reproduction Report', 'test-reports' ), 'bug-reproduction', 'github', true ); ?>
 
-					<?php $report_template->print_report_template( 'Test Report', 'patch-testing', 'trac', true ); ?>
-					<?php $report_template->print_report_template( 'Test Report', 'patch-testing', 'github', true ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Test Report', 'test-reports' ), 'patch-testing', 'trac', true ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Test Report', 'test-reports' ), 'patch-testing', 'github', true ); ?>
 
-					<?php $report_template->print_report_template( 'Security Vulnerability', 'security-vulnerability', 'github', true ); ?>
+					<?php $report_template->print_report_template( esc_html__( 'Security Vulnerability', 'test-reports' ), 'security-vulnerability', 'github', true ); ?>
 				</div>
 		</div>
 		<?php

--- a/src/Test_Reports/Settings.php
+++ b/src/Test_Reports/Settings.php
@@ -183,7 +183,7 @@ class Settings {
 					<div class="test-reports-options">
 						<div class="report-type">
 							<fieldset>
-								<legend><?php esc_html_e( 'Report Type:' ); ?></legend>
+								<legend><?php esc_html_e( 'Report Type:', 'test-reports' ); ?></legend>
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-type" value="bug-report" checked>
@@ -212,7 +212,7 @@ class Settings {
 						</div>
 						<div class="report-location">
 							<fieldset>
-								<legend><?php esc_html_e( 'Report Location:' ); ?></legend>
+								<legend><?php esc_html_e( 'Report Location:', 'test-reports' ); ?></legend>
 								<div class="test-reports-radio">
 									<label>
 										<input type="radio" name="report-location" value="trac" checked>

--- a/src/Test_Reports/Settings.php
+++ b/src/Test_Reports/Settings.php
@@ -130,7 +130,7 @@ class Settings {
 
 		add_submenu_page(
 			$parent,
-			esc_html__( 'Test Reports', 'test-reports' ),
+			esc_html_x( 'Test Reports', 'Page title', 'test-reports' ),
 			esc_html_x( 'Test Reports', 'Menu item', 'test-reports' ),
 			$capability,
 			'test-reports',
@@ -153,7 +153,7 @@ class Settings {
 		$wp_admin_bar->add_menu(
 			[
 				'id'    => 'test-reports',
-				'title' => '<span class="ab-icon" aria-hidden="true"></span><span class="ab-label">' . __( 'Test Reports', 'test-reports' ) . '</span>',
+				'title' => '<span class="ab-icon" aria-hidden="true"></span><span class="ab-label">' . _x( 'Test Reports', 'Menu item', 'test-reports' ) . '</span>',
 				'href'  => add_query_arg(
 					[ 'page' => 'test-reports' ],
 					is_multisite() ? network_admin_url( 'settings.php' ) : admin_url( 'tools.php' )
@@ -177,7 +177,7 @@ class Settings {
 		<div class="wrap">
 			<div class="test-reports">
 				<div class="test-reports-introduction">
-					<h1><?php esc_html_e( 'Test Reports', 'test-reports' ); ?></h1>
+					<h1><?php echo esc_html_x( 'Test Reports', 'Page title', 'test-reports' ); ?></h1>
 					<?php echo wp_kses_post( $introduction ); ?>
 
 					<div class="test-reports-options">


### PR DESCRIPTION
Hi @afragen 
Thanks for the plugin :)

Here are some issues I've fixed in the plugin i18n:
- [x] Add context to strings to separate 'Test Reports' from plugin brand name
- [x] Add missing textdomains
- [x] Wrap translatable strings in gettext

I've reverted the i18n on the reports titles, because it's used both in the title above the report, and the title within the actual report, and it's not desireable to translate the last one.

Happy new year!