### PR TITLE
Update Bug Reproduction and Patch Testing templates per test-handbook#104

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 [unreleased]
 * add data for subdirectory installation
+* update Bug Reproduction and Patch Testing templates per WordPress/test-handbook#104
 
 #### 1.2.1 / 2025-11-11
 * add GAs for releases and make-pot

--- a/src/Test_Reports/Report_Template.php
+++ b/src/Test_Reports/Report_Template.php
@@ -129,34 +129,23 @@ class Report_Template {
 		$sub_heading      = $is_wiki ? '===' : '###';
 		$last_item        = $is_wiki ? 'x' : '2';
 
+		if ( 'bug-reproduction' === $type || 'patch-testing' === $type ) {
+			return $this->get_testing_report_template( $type, $heading, $sub_heading, $last_item, $title );
+		}
+
 		$report  = ! $is_vulnerability ? "$heading $title\n" : '';
 		$report .= "$sub_heading Description\n" . $this->get_description( $type ) . "\n\n";
 		$report .= "$sub_heading Environment\n" . self::$environment_information . "\n\n";
 
-		if ( 'bug-report' === $type || 'security-vulnerability' === $type ) {
-			$report .= "$sub_heading Steps to Reproduce\n";
-			$report .= "1.&nbsp;\n";
-			$report .= "$last_item. 🐞 Bug occurs.\n\n";
+		$report .= "$sub_heading Steps to Reproduce\n";
+		$report .= "1.&nbsp;\n";
+		$report .= "$last_item. 🐞 Bug occurs.\n\n";
 
-			$report .= "$sub_heading Expected Results\n";
-			$report .= "1.&nbsp; ✅ What should happen.\n\n";
-		}
+		$report .= "$sub_heading Expected Results\n";
+		$report .= "1.&nbsp; ✅ What should happen.\n\n";
 
 		$report .= "$sub_heading Actual Results\n";
-		$report .= '1.&nbsp; ';
-
-		switch ( $type ) {
-			case 'bug-report':
-			case 'security-vulnerability':
-				$report .= "❌ What actually happened.\n\n";
-				break;
-			case 'bug-reproduction':
-				$report .= "✅ Error condition occurs (reproduced).\n\n";
-				break;
-			case 'patch-testing':
-				$report .= "✅ Issue resolved with patch.\n\n";
-				break;
-		}
+		$report .= "1.&nbsp; ❌ What actually happened.\n\n";
 
 		$report .= "$sub_heading Additional Notes\n";
 		$report .= "- Any additional details worth mentioning.\n\n";
@@ -168,6 +157,66 @@ class Report_Template {
 		}
 
 		$report .= 'Add as Attachment';
+
+		return str_replace( "\t", '', $report );
+	}
+
+	/**
+	 * Builds the Reproduction or Patch Testing report template.
+	 *
+	 * Structure follows the proposal in WordPress/test-handbook#104:
+	 * Environment, Steps taken (result as final step), Expected behavior/result,
+	 * Additional Notes, Screenshots/Screencast with results, Support Content.
+	 *
+	 * @param string $type        "bug-reproduction" or "patch-testing".
+	 * @param string $heading     Top-level heading marker for the format.
+	 * @param string $sub_heading Sub-heading marker for the format.
+	 * @param string $last_item   Marker used for the final list item ("x" for Trac, "2" for GitHub).
+	 * @param string $title       The title of the report template.
+	 * @return string The test report template.
+	 */
+	private function get_testing_report_template( $type, $heading, $sub_heading, $last_item, $title ) {
+		$is_patch = 'patch-testing' === $type;
+
+		$report = "$heading $title\n";
+
+		if ( $is_patch ) {
+			$report .= "Patch tested: REPLACE_WITH_PATCH_URL\n\n";
+		}
+
+		$report .= "$sub_heading Environment\n" . self::$environment_information . "\n\n";
+
+		$report .= "$sub_heading Steps taken\n";
+		$report .= "1.&nbsp;\n";
+		$report .= "$last_item. ";
+		$report .= $is_patch
+			? "✅ Patch is solving the problem / ❌ Patch is failing\n\n"
+			: "🐞 Bug occurs / ❌ Bug is not occurring\n\n";
+
+		if ( $is_patch ) {
+			$report .= "$sub_heading Expected result\n";
+			$report .= "- Explain what results you were expecting from this patch.\n\n";
+		} else {
+			$report .= "$sub_heading Expected behavior\n";
+			$report .= "- Explain what behavior you were expecting from the ticket information.\n\n";
+		}
+
+		$report .= "$sub_heading Additional Notes\n";
+		$report .= "- Any additional details worth mentioning.\n\n";
+
+		$report .= "$sub_heading Screenshots/Screencast with results\n";
+		$report .= $is_patch
+			? "- Screenshot/Screencast before\n- Screenshot/Screencast after\n\n"
+			: "- Screenshot showcasing the problem or the bug not occurring.\n\n";
+
+		$report .= "$sub_heading Support Content\n";
+		$report .= "- Here you can add any support content useful for testing.\n";
+		$report .= "For example:\n";
+		$report .= "1. Blueprint JSON\n";
+		$report .= "2. Website Playground URL with parameters\n";
+		$report .= "3. Snippets of code\n";
+		$report .= "4. Additional Screenshots\n";
+		$report .= '5. etc...';
 
 		return str_replace( "\t", '', $report );
 	}
@@ -200,21 +249,13 @@ class Report_Template {
 	 * Descriptions are intentionally not translated as they are
 	 * intended for posting in English-language ticketing systems.
 	 *
-	 * @param string $type The report type. "bug-report", "bug-reproduction", "patch-testing"
-	 *                     or "security-vulnerability".
+	 * @param string $type The report type. "bug-report" or "security-vulnerability".
 	 * @return string The description.
 	 */
 	private function get_description( $type ) {
 		switch ( $type ) {
 			case 'bug-report':
 				$description = 'Describe the bug.';
-				break;
-			case 'bug-reproduction':
-				$description = 'This report validates whether the issue can be reproduced.';
-				break;
-			case 'patch-testing':
-				$description  = "This report validates whether the indicated patch works as expected.\n\n";
-				$description .= 'Patch tested: REPLACE_WITH_PATCH_URL';
 				break;
 			case 'security-vulnerability':
 				$description = 'Describe the security vulnerability.';


### PR DESCRIPTION
## Summary

Updates the **Bug Reproduction** and **Patch Testing** templates to match the new format being officialized in the WordPress Test Handbook.

This is the **plugin-side counterpart** to:
- Handbook discussion: [WordPress/test-handbook#104](https://github.com/WordPress/test-handbook/issues/104)
- Handbook PR (open): [WordPress/test-handbook#166](https://github.com/WordPress/test-handbook/pull/166) — *Update reproduction and patch testing report templates*

Once the handbook PR lands, the templates served by this plugin should match the documented format so testers see one consistent structure across the handbook and the plugin.

The **Bug Report** and **Security Vulnerability** templates are intentionally left unchanged — the handbook proposal only covers the two testing report types.

## Proposal (from test-handbook#104 / #166)

The consensus reached in the handbook discussion (proposed by @SirLouen, endorsed by @huzaifaalmesbah, @Successfulsebunya, @ozgursar) is to standardize the reproduction and patch testing reports around a more testing-focused structure where **the result is the final step in 'Steps taken'**, rather than a separate \"Actual Results\" section.

### Reproduction Report

```
## Bug Reproduction Report

### Environment
- WordPress:
- PHP:
- Server:
- Database:
- Browser:
- OS:
- Theme:
- MU Plugins:
- Plugins:

### Steps taken
1.
x. 🐞 Bug occurs / ❌ Bug is not occurring

### Expected behavior
- Explain what behavior you were expecting from the ticket information.

### Additional Notes
- Any additional details worth mentioning.

### Screenshots/Screencast with results
- Screenshot showcasing the problem or the bug not occurring.

### Support Content
- Here you can add any support content useful for testing.
For example:
1. Blueprint JSON
2. Website Playground URL with parameters
3. Snippets of code
4. Additional Screenshots
5. etc...
```

### Patch Testing Report

```
## Patch Testing Report
Patch tested: REPLACE_WITH_PATCH_URL

### Environment
- ...

### Steps taken
1.
x. ✅ Patch is solving the problem / ❌ Patch is failing

### Expected result
- Explain what results you were expecting from this patch.

### Additional Notes
- ...

### Screenshots/Screencast with results
- Screenshot/Screencast before
- Screenshot/Screencast after

### Support Content
- ...
```

## Why this change is needed

- The current templates mix \"bug report\" semantics (Description / Steps to Reproduce / Expected Results / Actual Results) into reports whose purpose is **testing**, not bug filing. Reviewers and testers have repeatedly noted this mismatch in the handbook discussion.
- Testers are forced to re-state \"Expected behavior\" / \"Actual result\" content that the **original reporter** or **patch author** has already provided in the ticket. This is redundant and slows reviews.
- A separate **Screenshots/Screencast with results** section makes visual evidence a first-class part of the report (especially needed for before/after patch comparisons).
- A dedicated **Support Content** section gives testers a clear place to share Blueprint JSON, Playground URLs, code snippets, etc. — the kinds of supporting artifacts that are increasingly important in modern WordPress testing workflows.
- Most importantly: the **handbook is being updated to this format in [#166](https://github.com/WordPress/test-handbook/pull/166)**. Keeping the plugin in sync avoids confusing testers with two different official templates.

## Benefits

- **Single source of truth.** Plugin output matches the format documented in the Test Handbook.
- **Faster, clearer testing reports.** The flow mirrors what a tester actually does: set up environment → perform steps → observe result.
- **Less duplication with the originating ticket.** Testers focus on what they did and what happened, not on re-describing the bug.
- **Better support for Playground / Blueprint workflows** via the explicit Support Content section.
- **Result is unambiguous** as the final step of the reproduction/patch testing flow, matching how testers naturally write reports (consensus reached in the handbook issue).
- **Bug Report and Security Vulnerability templates are unaffected**, so existing Trac/HackerOne workflows continue to work exactly as before.

## Implementation notes

- New private method \`get_testing_report_template()\` builds the structure for both \`bug-reproduction\` and \`patch-testing\`.
- Patch Testing inserts \`Patch tested: REPLACE_WITH_PATCH_URL\` at the top, replacing the previous Description-based approach.
- Trac (\`==\` / \`===\`) and GitHub (\`##\` / \`###\`) heading markers are preserved; the trac-specific \`x.\` final list item marker is preserved.
- Dead \`bug-reproduction\` and \`patch-testing\` cases removed from \`get_description()\`.
- No JS/CSS changes required — no hardcoded references to the old section names.

## Test plan

- [ ] Open the Test Reports admin page.
- [ ] Select **Bug Reproduction** + **GitHub** → verify sections match the proposal above, result appears as step 2.
- [ ] Select **Bug Reproduction** + **Trac** → verify `==` `===` headings and `x.` final list marker.
- [ ] Select **Patch Testing** + **GitHub** → verify `Patch tested: REPLACE_WITH_PATCH_URL` at top, Expected result + before/after screenshot lines present.
- [ ] Select **Patch Testing** + **Trac** → verify wiki heading markers and `x.` final list marker.
- [ ] Select **Bug Report** (Trac and GitHub) → confirm template is unchanged.
- [ ] Select **Security Vulnerability** → confirm template is unchanged.
- [ ] Click **Copy to clipboard** for each → confirm `&nbsp;` is replaced with regular space in the clipboard payload.
- [ ] Cross-check rendered output against WordPress/test-handbook#166 once that PR lands.

## References

- Handbook discussion: WordPress/test-handbook#104
- Handbook PR: WordPress/test-handbook#166 *(officializes this new format in the handbook itself)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)