### PR TITLE
Fix: keep report templates a consistent width

### DIFF
--- a/src/css/test-reports-template.css
+++ b/src/css/test-reports-template.css
@@ -36,6 +36,8 @@
 
 .test-reports .template {
 	padding-bottom: 2rem;
+	width: 600px;
+	max-width: 100%;
 }
 
 .test-reports .template-buttons {
@@ -57,4 +59,10 @@
 
 .test-reports .card {
 	margin-top: 1rem;
+}
+
+@media screen and (max-width: 782px) {
+	.test-reports .template {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
## Summary

Report templates changed width depending on the selected report type (e.g. Bug Report rendered wider, Patch Testing narrower) because each card sized itself to its text content.

## Changes

- Give `.test-reports .template` a fixed `600px` width (with `max-width: 100%`) so all report types render at the same width.
- Drop the template to full width below the `782px` mobile breakpoint so it stays fluid on small screens.

## Testing

- Switched between Bug Report, Bug Reproduction, Patch Testing, and Security Vulnerability — all keep the same width.
- Verified on mobile widths that the template goes full width without horizontal overflow.